### PR TITLE
Switch to at_compile_time since compile_time has been officially deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 rhsm Cookbook CHANGELOG
-==============
+=======================
 
 This file is used to list changes made in each version of the rhsm cookbook.
+
+1.0.1
+-----
+- Switch to at\_compile\_time since compile\_time has been officially deprecated
 
 1.0.0
 -----

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@rightscale.com'
 license          'Apache 2.0'
 description      'Provides recipes to manage registration using RedHat Subscription Manager'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.0.0'
+version          '1.0.1'
 
 supports 'redhat'
 

--- a/recipes/register.rb
+++ b/recipes/register.rb
@@ -31,7 +31,7 @@ if node['platform'] == 'redhat'
   end
 
   # If system is currently unregistered, register it.
-  compile_time do
+  at_compile_time do
     execute 'register instance with redhat.com' do
       command "subscription-manager register --username #{rhsm_username} --password #{rhsm_password} --auto-attach"
       not_if 'subscription-manager identity'
@@ -40,7 +40,7 @@ if node['platform'] == 'redhat'
 
   unless additional_repos.empty?
     additional_repos.each do |repo|
-      compile_time do
+      at_compile_time do
         execute 'enabling additional repo' do
           command "subscription-manager repos --enable=#{repo}"
         end

--- a/recipes/unregister.rb
+++ b/recipes/unregister.rb
@@ -19,7 +19,7 @@
 
 if node['platform'] == 'redhat'
   # If system is registered, unregister it.
-  compile_time do
+  at_compile_time do
     execute 'unregister instance with redhat.com' do
       command 'subscription-manager unregister'
       only_if 'subscription-manager identity'


### PR DESCRIPTION
I ran into this problem running Chef 12.1+ as it failed during the run instead of just a warning.
